### PR TITLE
Action cableの実装

### DIFF
--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -1,0 +1,9 @@
+class MessageChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -1,6 +1,6 @@
 class MessageChannel < ApplicationCable::Channel
   def subscribed
-    # stream_from "some_channel"
+    stream_from "message_channel"
   end
 
   def unsubscribed

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,6 +6,9 @@ class MessagesController < ApplicationController
 
   def create
     @message = Message.new(text: params[:message][:text])
+    if @message.save
+      ActionCable.server.broadcast 'message_channel', content: @message
+    end
   end
 
 end

--- a/app/javascript/channels/message_channel.js
+++ b/app/javascript/channels/message_channel.js
@@ -1,0 +1,15 @@
+import consumer from "./consumer"
+
+consumer.subscriptions.create("MessageChannel", {
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    // Called when there's incoming data on the websocket for this channel
+  }
+});

--- a/app/javascript/channels/message_channel.js
+++ b/app/javascript/channels/message_channel.js
@@ -10,6 +10,10 @@ consumer.subscriptions.create("MessageChannel", {
   },
 
   received(data) {
-    // Called when there's incoming data on the websocket for this channel
+    const html = `<p>${data.content.text}</p>`;
+    const messages = document.getElementById('messages');
+    const newMessage = document.getElementById('message_text');
+    messages.insertAdjacentHTML('afterbegin', html);
+    newMessage.value='';
   }
 });

--- a/test/channels/message_channel_test.rb
+++ b/test/channels/message_channel_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MessageChannelTest < ActionCable::Channel::TestCase
+  # test "subscribes" do
+  #   subscribe
+  #   assert subscription.confirmed?
+  # end
+end


### PR DESCRIPTION
# What
Action cableの実装
# Why
非同期通信でメッセージをリアルタイムで表示させる為